### PR TITLE
feat: 更新库存时会跳过获取信息失败的漫画并弹出警告

### DIFF
--- a/src-tauri/src/errors.rs
+++ b/src-tauri/src/errors.rs
@@ -7,7 +7,7 @@ use crate::extensions::AnyhowErrorToStringChain;
 pub type CommandResult<T> = Result<T, CommandError>;
 
 #[derive(Debug, Type)]
-pub struct CommandError(String);
+pub struct CommandError(pub String);
 impl Serialize for CommandError {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -106,6 +106,12 @@ pub enum UpdateDownloadedComicsEvent {
     GettingComics { total: i64 },
 
     #[serde(rename_all = "camelCase")]
+    GetComicError {
+        comic_title: String,
+        err_msg: String,
+    },
+
+    #[serde(rename_all = "camelCase")]
     ComicGot { current: i64, total: i64 },
 
     #[serde(rename_all = "camelCase")]

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -214,7 +214,7 @@ export type Pagination<T> = { list: T[]; total: number; limit: number; offset: n
 export type RestrictRespData = { value: number; display: string }
 export type SearchRespData = Pagination<ComicInSearchRespData>
 export type Theme = { name: string; path_word: string }
-export type UpdateDownloadedComicsEvent = { event: "GettingComics"; data: { total: number } } | { event: "ComicGot"; data: { current: number; total: number } } | { event: "DownloadTaskCreated" }
+export type UpdateDownloadedComicsEvent = { event: "GettingComics"; data: { total: number } } | { event: "GetComicError"; data: { comicTitle: string; errMsg: string } } | { event: "ComicGot"; data: { current: number; total: number } } | { event: "DownloadTaskCreated" }
 export type UserProfileRespData = { user_id: string; username: string; nickname: string; avatar: string; datetime_created: string; ticket: number; reward_ticket: number; downloads: number; vip_downloads: number; reward_downloads: number; scy_answer: boolean; day_downloads_refresh: string; day_downloads: number }
 
 /** tauri-specta globals **/


### PR DESCRIPTION
解决这个issue #41 